### PR TITLE
fix: RE-Update again `script/*.sh` script paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,11 +31,11 @@ jobs:
 
       # 1. 모든 스크립트 실행권한 보장
       - name: Ensure all scripts are executable
-        run: chmod +x platform-optimal-hash/library/bump-gradle-version.sh platform-optimal-hash/scripts/*.sh
+        run: chmod +x ./.github/workflows/scripts/bump-gradle-version.sh ./scripts/*.sh
 
       # 2. build.gradle.kts 버전 증가
       - name: Bump Gradle version
-        run: platform-optimal-hash/library/bump-gradle-version.sh
+        run: ./.github/workflows/scripts/bump-gradle-version.sh
 
       # 3. Xcode 설정
       - name: Set up Xcode
@@ -62,19 +62,19 @@ jobs:
       # 7. 버전 결정 (외부 스크립트 사용)
       - name: Github Workflow determine Version
         id: version # 스텝 ID 설정하여 출력값 참조
-        run: platform-optimal-hash/scripts/github-determine-version.sh
+        run: ./.github/workflows/scripts/github-determine-version.sh
         env:
           WORKFLOW_INPUT_VERSION: ${{ github.event.inputs.version }}
           WORKFLOW_GITHUB_REF: ${{ github.ref }}
 
       # 8. 패키징 및 바이너리 복사 (기존 스크립트 사용)
       - name: Package and Copy Binaries
-        run: platform-optimal-hash/scripts/package-binaries.sh "${{ steps.version.outputs.version_num }}" "library" "bin"
+        run: ./.github/workflows/scripts/package-binaries.sh "${{ steps.version.outputs.version_num }}" "library" "bin"
 
       # 9. 저장소에 바이너리 커밋 및 푸시 (태그 푸시 시에만)
       - name: Commit and Push Binaries to Main Branch
         if: startsWith(github.ref, 'refs/tags/') # 태그 푸시 시에만 실행
-        run: platform-optimal-hash/scripts/commit-push-binaries.sh
+        run: ./.github/workflows/scripts/commit-push-binaries.sh
         env:
           INPUT_VERSION_TAG: ${{ steps.version.outputs.version_tag }}
           INPUT_GIT_USER_NAME: github-actions[bot]


### PR DESCRIPTION
#### 🚀 **주요 변경 사항**
1. **🔧 GitHub Actions 워크플로우 추가**
   - 플랫폼 바이너리 배포를 위한 `publish.yml` 워크플로우 추가
   - 스크립트 경로 수정 및 실행 권한 보장 (`script/*.sh`)

2. **⚡ 최적 해싱 함수 개선**
   - 데이터 타입 개선 및 오류 처리 추가
   - 네이티브 함수 이름 업데이트

3. **🛠️ Gradle 설정 리팩토링**
   - `copyReleaseLibBinaries` Task 제거
   - `iosSimulatorArm64` 대상 제거 (GitHub Actions에서 처리)

4. **🔨 빌드 구성 업데이트**
   - `optimal_hash` 라이브러리 빌드 구성 업데이트
   - 바이너리 복사 작업 추가

5. **📦 기타**
   - 초기 KMP 프로젝트 설정 및 의존성 업데이트
   - 테스트 및 최적 해싱 함수 구현