### PR TITLE
refactor(workflows): PR 검증 및 태그 기반 릴리스 GH 워크플로우 개선

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,94 +1,119 @@
 # 워크플로우 이름
-name: Publish & Copy platform binaries
+# [수정] 역할에 맞게 이름 변경 (PR 검증 및 태그 릴리스)
+name: PR Check & Release on Tag
 
 # 워크플로우 트리거 조건
 on:
-  push:
+  # [수정] main 브랜치 대상 Pull Request 발생/업데이트 시 실행 (커밋 전 검증 목적)
+  pull_request:
     branches: [ main ]
     paths:
-      - './.github/**'  # Github Action script 변경 시 실행
-      - './library/**'  # library 하위 내용 변경 시 실행
+     - '.github/**'
+     - 'library/**'
+      # 필요에 따라 다른 경로 추가
+
+  # [유지] v* 태그 푸시 시 실행 (릴리스 생성 목적)
+  push:
     tags:
-      - 'v*'  # v로 시작하는 태그 푸시 시에만 실행
-  workflow_dispatch: # 수동 트리거
+      - 'v*'
+
+  # [유지] 수동 실행
+  workflow_dispatch:
     inputs:
       version:
         description: '릴리스 버전 (예: 1.0.0)'
         required: false
         default: ''
 
+# [중요] PR 기반 워크플로우를 효과적으로 사용하려면, GitHub 저장소 설정에서
+# 'main' 브랜치에 대한 보호 규칙(Branch Protection Rule)을 설정해야 합니다.
+# 규칙 내용:
+# 1. Require status checks to pass before merging 활성화
+# 2. Status checks 목록에서 이 워크플로우의 Job 이름(예: 'build-check-release') 선택
+
 jobs:
-  build-commit-release:
+  # [수정] Job 이름 변경
+  build-check-release:
     runs-on: macos-latest # Apple 플랫폼 빌드를 위해 macOS 사용
-    
     steps:
       # 0. 소스 코드 체크아웃
-      #    저장소 푸시를 위해 충분한 권한이 있는 토큰 설정 (예: PAT)
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # 저장소 쓰기 권한이 있는 토큰 사용 권장
-          token: ${{ secrets.GITHUB_TOKEN }} # 기본 토큰 사용 (권한 부족 시 PAT로 변경)
-      
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       # 1. 모든 쉘 스크립트 실행권한 보장
       - name: 1. Ensure all scripts are executable
         run: chmod +x ./.github/workflows/scripts/*.sh
-      
-      # build.gradle.kts 버전 증가
-      - name: 2. Bump Gradle version
-        run: ./.github/workflows/scripts/bump-gradle-version.sh
-      
-      # Xcode 설정
+
+      # 2. Gradle 버전 자동 증가 (필요시 활성화)
+      #    - 주의: PR 워크플로우에서는 버전 범프를 실행하면 충돌 가능성 있음
+      #    - 태그 기반 릴리스 시에만 실행하거나, 별도 관리 권장
+      # - name: 2. Bump Gradle version
+      #   if: startsWith(github.ref, 'refs/tags/') # 태그 푸시 시에만 실행 권장
+      #   run: ./.github/workflows/scripts/bump-gradle-version.sh
+
+      # 3. Xcode 설정
       - name: 3. Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
-      
-      # JDK 설정
+          # 특정 버전 명시 권장 (예: '15.2')
+          xcode-version: '15.2' # latest-stable 대신 특정 버전 사용
+
+      # 4. JDK 설정
       - name: 4. Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-      
-      # Gradle 설정 (JDK 17 포함 및 캐싱 최적화)
+
+      # 5. Gradle 설정
       - name: 5. Set up Gradle
         uses: gradle/gradle-build-action@v3
         with:
           cache-disabled: false
-          # arguments: :library:writeLibraryName assemble # Gradle 태스크 추가 예시
-      
-      # 모든 타겟 빌드
+          # Gradle 빌드 최적화 옵션 추가 고려 (예: configuration-cache)
+          arguments: --configuration-cache assemble # 예시
+
+      # 6. 빌드 실행 (릴리스에 필요한 태스크만 실행 권장)
       - name: 6. Build all targets
         run: ./gradlew assemble # 또는 Gradle 태스크 추가 시 해당 태스크 포함
-      
-      # 버전 결정 (외부 스크립트 사용)
-      - name: 7. Github Workflow determine Version
-        id: version # 스텝 ID 설정하여 출력값 참조
+
+      # 7. 버전 결정
+      #    - PR 시에는 버전 결정이 불필요할 수 있음 (태그/수동 입력 기반)
+      #    - 이 스텝은 태그/수동 실행 시에만 필요할 수 있으므로 조건 추가 고려
+      - name: 7. Determine Version
+        id: version
+        # [수정] 태그 또는 수동 실행 시에만 버전 결정 필요
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         run: ./.github/workflows/scripts/github-determine-version.sh
         env:
           WORKFLOW_INPUT_VERSION: ${{ github.event.inputs.version }}
           WORKFLOW_GITHUB_REF: ${{ github.ref }}
-      
-      # 패키징 및 바이너리 복사 (기존 스크립트 사용)
-      - name: 8. Package and Copy Binaries
-        run: ./.github/workflows/scripts/package-binaries.sh "${{ steps.version.outputs.version_num }}" "library" "bin"
-      
-      # 저장소에 바이너리 커밋 및 푸시 (태그 푸시 시에만)
+
+      # 8. 바이너리 패키징
+      #    - PR 검증 시에도 패키징 자체는 실행하여 확인 가능
+      - name: 8. Package Binaries
+        run: ./.github/workflows/scripts/package-binaries.sh "${{ steps.version.outputs.version_num || 'pr-check' }}" "library" "bin"
+        # PR 시에는 version_num 이 없을 수 있으므로 기본값(예: pr-check) 사용
+
+      # [수정] 태그 푸시 시에만 바이너리 커밋
       - name: 9. Commit and Push Binaries to Main Branch
         if: startsWith(github.ref, 'refs/tags/')
         run: ./.github/workflows/scripts/commit-push-binaries.sh
         env:
+          # commit-push-binaries.sh 스크립트가 version_tag 없이도 동작 가능한지 확인 필요
           INPUT_VERSION_TAG: ${{ steps.version.outputs.version_tag }}
-          INPUT_GIT_USER_NAME: github-actions[bot]
-          INPUT_GIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
-      
-      # GitHub Release 생성 및 에셋 업로드
+          INPUT_GIT_USER_NAME: GH-Action[bot]
+          INPUT_GIT_USER_EMAIL: GH-Action[bot]@noreply.github.com
+
+      # [유지] 태그 푸시 시에만 GitHub 릴리스 생성
       - name: 10. Create Release and Upload Assets
+        if: startsWith(github.ref, 'refs/tags/') # 태그 푸시 시에만 릴리스 실행
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version_num }}
-          name: Release ${{ steps.version.outputs.version_num }}
+          tag_name: ${{ steps.version.outputs.version_tag }} # github-determine-version.sh 결과 사용
+          name: Release ${{ steps.version.outputs.version_num }} # github-determine-version.sh 결과 사용
           draft: false
           prerelease: false
           files: |
@@ -96,7 +121,7 @@ jobs:
             bin/*/* # 모든 플랫폼의 최종 바이너리 파일 업로드
           generate_release_notes: true
           body: |
-            ## Platform binary release v${{ steps.version.outputs.version_num }}
+            ## Platform binary release ${{ steps.version.outputs.version_tag }}
             바이너리는 하나의 zip 파일과 아래의 개별 에셋으로 제공됩니다.
             개별 바이너리는 리포지토리의 `./bin` 디렉토리(`main` 브랜치에 커밋됨)에서 직접 사용할 수도 있습니다.
             **Included Platforms:** (실제 빌드 대상에 따라 이 목록을 업데이트하세요.)
@@ -105,6 +130,3 @@ jobs:
             - macOS (arm64, x64)
             - Windows (x64)
             - Linux (x64)
-        env:
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/package-binaries.sh
+++ b/.github/workflows/scripts/package-binaries.sh
@@ -110,8 +110,8 @@ for PLATFORM in ${PLATFORMS}; do
 
     echo "바이너리 검색 위치: ${BIN_DIR}"
 
-    # 해당 확장자를 가진 파일들을 찾아서 처리
-    find "${BIN_DIR}" -maxdepth 1 -type f -name "*.${EXT}" | while IFS= read -r src_file; do
+    # 프로세스 치환(< <(...))을 사용하여 while 루프가 subshell에서 실행되지 않도록 함
+    while IFS= read -r src_file; do
         filename=$(basename "$src_file")
 
         # 파일명에 BINARY_FILENAME 이 포함되어 있는지 확인 ('lib' 접두사 유무 관계 없음)
@@ -125,7 +125,8 @@ for PLATFORM in ${PLATFORMS}; do
         else
             echo "파일명 불일치 (무시): ${filename} (BINARY_FILENAME '${BINARY_FILENAME}' 미포함)"
         fi
-    done
+    # 프로세스 치환 사용
+    done < <(find "${BIN_DIR}" -maxdepth 1 -type f -name "*.${EXT}")
 
     # 파일 찾기 결과 확인
     if [ $found -eq 0 ]; then


### PR DESCRIPTION
# GitHub Actions 워크플로우 실행 전략을 변경하고 안정성을 개선합니다.
- 워크플로우 주 트리거를 'main' 브랜치 대상 Pull Request로 변경하여 커밋 전 코드 검증을 수행합니다.
- 태그('v*') 푸시 시에만 바이너리 커밋 및 GitHub 릴리스 생성이 실행되도록 조건을 명확히 합니다.
- 'package-binaries.sh' 스크립트의 바이너리 탐지 로직 오류를 수정하여 불필요한 경고 메시지를 제거합니다.
- Xcode 버전을 명시하여 실행 환경의 일관성을 높입니다.

이를 통해 코드 병합 전 안정성을 확보하고, 릴리스 프로세스를 표준화하며, 워크플로우 로그 가독성을 향상시킵니다. 'main' 브랜치 보호 규칙 설정이 필요합니다.